### PR TITLE
Add draft post support with publish workflow

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,7 +15,7 @@ import {
   getOrigin,
 } from "../lib/auth";
 import type { UserRecord } from "../lib/auth";
-import { createPost, postExists, deletePost, slugify } from "../lib/blog";
+import { createPost, postExists, deletePost, publishPost, slugify } from "../lib/blog";
 import type { BlogPost } from "../lib/blog";
 import { env } from "cloudflare:workers";
 
@@ -31,6 +31,7 @@ export const server = {
         tags: z.array(z.string()),
         categories: z.array(z.string()),
         content: z.string().min(1),
+        draft: z.boolean().optional().default(false),
       }),
       handler: async (input, context) => {
         if (!(await isAuthenticated(context))) {
@@ -66,6 +67,21 @@ export const server = {
           });
         }
         await deletePost(slug);
+        return { ok: true };
+      },
+    }),
+
+    publish: defineAction({
+      accept: "json",
+      input: z.object({ slug: z.string().min(1) }),
+      handler: async ({ slug }, context) => {
+        if (!(await isAuthenticated(context))) {
+          throw new ActionError({
+            code: "FORBIDDEN",
+            message: "Not authenticated",
+          });
+        }
+        await publishPost(slug);
         return { ok: true };
       },
     }),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,7 @@ const blog = defineCollection({
     description: z.string(),
     tags: z.array(z.string()),
     categories: z.array(z.string()),
+    draft: z.boolean().optional().default(false),
   }),
 });
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -11,6 +11,7 @@ export interface BlogPost {
   tags: string[];
   categories: string[];
   content: string;
+  draft: boolean;
 }
 
 const GITHUB_REPO_OWNER = "johnpangalos";
@@ -119,6 +120,7 @@ function buildMdxContent(post: Omit<BlogPost, "slug">): string {
     `description: "${post.description}"`,
     `tags: [${post.tags.map((t) => `"${t}"`).join(", ")}]`,
     `categories: [${post.categories.map((c) => `"${c}"`).join(", ")}]`,
+    `draft: ${post.draft}`,
     "---",
   ].join("\n");
 
@@ -147,7 +149,7 @@ export async function createPost(
 }
 
 export async function listPosts(): Promise<
-  { name: string; slug: string; sha: string }[]
+  { name: string; slug: string; sha: string; draft: boolean }[]
 > {
   const octokit = getOctokit();
 
@@ -160,13 +162,39 @@ export async function listPosts(): Promise<
 
     if (!Array.isArray(data)) return [];
 
-    return data
-      .filter((f) => f.type === "file" && f.name.endsWith(".mdx"))
-      .map((f) => ({
-        name: f.name.replace(/\.mdx$/, ""),
-        slug: f.name.replace(/\.mdx$/, ""),
-        sha: f.sha,
-      }));
+    const files = data.filter(
+      (f) => f.type === "file" && f.name.endsWith(".mdx"),
+    );
+
+    const posts = await Promise.all(
+      files.map(async (f) => {
+        let draft = false;
+        try {
+          const { data: fileData } = await octokit.repos.getContent({
+            owner: GITHUB_REPO_OWNER,
+            repo: GITHUB_REPO_NAME,
+            path: f.path,
+          });
+          if (!Array.isArray(fileData) && "content" in fileData && fileData.content) {
+            const content = atob(fileData.content.replace(/\n/g, ""));
+            const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+            if (match) {
+              draft = /^draft:\s*true\s*$/m.test(match[1]);
+            }
+          }
+        } catch {
+          // If we can't read the file, assume not a draft
+        }
+        return {
+          name: f.name.replace(/\.mdx$/, ""),
+          slug: f.name.replace(/\.mdx$/, ""),
+          sha: f.sha,
+          draft,
+        };
+      }),
+    );
+
+    return posts;
   } catch (e: unknown) {
     if (e instanceof Error && "status" in e && (e as { status: number }).status === 404) return [];
     throw e;
@@ -194,6 +222,42 @@ export async function deletePost(
     repo: GITHUB_REPO_NAME,
     path: filePath,
     message: `Delete blog post: ${slug}`,
+    sha: data.sha,
+  });
+}
+
+export async function publishPost(slug: string): Promise<void> {
+  const octokit = getOctokit();
+  const filePath = `${CONTENT_PATH}/${slug}.mdx`;
+
+  const { data } = await octokit.repos.getContent({
+    owner: GITHUB_REPO_OWNER,
+    repo: GITHUB_REPO_NAME,
+    path: filePath,
+  });
+
+  if (Array.isArray(data) || !("content" in data) || !data.content) {
+    throw new Error(`Post not found: ${slug}`);
+  }
+
+  const content = atob(data.content.replace(/\n/g, ""));
+  const updatedContent = content.replace(
+    /^(---\s*\n[\s\S]*?)draft:\s*true\s*\n([\s\S]*?---)/m,
+    "$1draft: false\n$2",
+  );
+
+  const encodedContent = btoa(
+    new TextEncoder()
+      .encode(updatedContent)
+      .reduce((acc, byte) => acc + String.fromCharCode(byte), ""),
+  );
+
+  await octokit.repos.createOrUpdateFileContents({
+    owner: GITHUB_REPO_OWNER,
+    repo: GITHUB_REPO_NAME,
+    path: filePath,
+    message: `Publish blog post: ${slug}`,
+    content: encodedContent,
     sha: data.sha,
   });
 }

--- a/src/pages/admin/_components/PublishPostButton.tsx
+++ b/src/pages/admin/_components/PublishPostButton.tsx
@@ -1,0 +1,29 @@
+import { actions } from "astro:actions";
+import { Button } from "react-aria-components";
+
+interface Props {
+  slug: string;
+}
+
+export default function PublishPostButton({ slug }: Props) {
+  const handlePublish = async () => {
+    if (!confirm(`Publish "${slug}"? This will make it live after the site rebuilds.`))
+      return;
+
+    const { error } = await actions.blog.publish({ slug });
+    if (error) {
+      alert(`Error: ${error.message}`);
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <Button
+      onClick={handlePublish}
+      className="rounded bg-green-600 px-2 py-1 text-xs text-white hover:bg-green-700"
+    >
+      Publish
+    </Button>
+  );
+}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -4,12 +4,13 @@ import { isAuthenticated } from "../../lib/auth";
 import { listPosts } from "../../lib/blog";
 import LogoutButton from "./_components/LogoutButton";
 import DeletePostButton from "./_components/DeletePostButton";
+import PublishPostButton from "./_components/PublishPostButton";
 
 if (!(await isAuthenticated(Astro))) {
   return Astro.redirect("/admin/login");
 }
 
-let posts: { name: string; slug: string; sha: string }[] = [];
+let posts: { name: string; slug: string; sha: string; draft: boolean }[] = [];
 let listError: string | null = null;
 
 try {
@@ -47,15 +48,25 @@ try {
           <ul class="mt-4 space-y-3">
             {posts.map((post) => (
               <li class="flex items-center justify-between rounded border border-stone-200 p-3 dark:border-stone-700">
-                <div>
+                <div class="flex items-center gap-2">
                   <a
                     href={`/blog/${post.slug}`}
                     class="font-bold text-fuchsia-700 hover:underline dark:text-fuchsia-400"
                   >
                     {post.name}
                   </a>
+                  {post.draft && (
+                    <span class="rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                      Draft
+                    </span>
+                  )}
                 </div>
-                <DeletePostButton client:load slug={post.slug} />
+                <div class="flex gap-2">
+                  {post.draft && (
+                    <PublishPostButton client:load slug={post.slug} />
+                  )}
+                  <DeletePostButton client:load slug={post.slug} />
+                </div>
               </li>
             ))}
           </ul>

--- a/src/pages/admin/new/_components/NewPostForm.tsx
+++ b/src/pages/admin/new/_components/NewPostForm.tsx
@@ -15,10 +15,16 @@ export default function NewPostForm() {
     type: "idle" | "loading" | "success" | "error";
   }>({ message: "", type: "idle" });
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (
+    e: React.FormEvent<HTMLFormElement>,
+    draft: boolean,
+  ) => {
     e.preventDefault();
 
-    setStatus({ message: "Publishing...", type: "loading" });
+    setStatus({
+      message: draft ? "Saving draft..." : "Publishing...",
+      type: "loading",
+    });
 
     const formData = new FormData(e.currentTarget);
     const tagsRaw = (formData.get("tags") as string) || "";
@@ -41,6 +47,7 @@ export default function NewPostForm() {
       tags,
       categories,
       content: formData.get("content") as string,
+      draft,
     });
 
     if (error) {
@@ -49,8 +56,9 @@ export default function NewPostForm() {
     }
 
     setStatus({
-      message:
-        "Post committed to repo! It will be live after the site rebuilds.",
+      message: draft
+        ? "Draft saved to repo!"
+        : "Post committed to repo! It will be live after the site rebuilds.",
       type: "success",
     });
     setTimeout(() => {
@@ -62,7 +70,10 @@ export default function NewPostForm() {
     "mt-1 w-full rounded border border-stone-300 bg-white px-3 py-2 text-stone-900 dark:border-stone-600 dark:bg-stone-800 dark:text-white";
 
   return (
-      <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+      <form
+        onSubmit={(e) => handleSubmit(e, false)}
+        className="mt-8 space-y-4"
+      >
         <TextField>
           <Label className="block text-sm font-bold">Title</Label>
           <Input
@@ -152,12 +163,29 @@ export default function NewPostForm() {
           </div>
         )}
 
-        <Button
-          type="submit"
-          className="rounded bg-fuchsia-700 px-4 py-2 font-bold text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
-        >
-          Publish
-        </Button>
+        <div className="flex gap-3">
+          <Button
+            type="submit"
+            className="rounded bg-fuchsia-700 px-4 py-2 font-bold text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
+          >
+            Publish
+          </Button>
+          <Button
+            type="button"
+            onPress={(e) => {
+              const form = (e.target as HTMLElement).closest("form");
+              if (form && form.reportValidity()) {
+                handleSubmit(
+                  { preventDefault: () => {}, currentTarget: form } as React.FormEvent<HTMLFormElement>,
+                  true,
+                );
+              }
+            }}
+            className="rounded border border-stone-300 bg-white px-4 py-2 font-bold text-stone-700 hover:bg-stone-100 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+          >
+            Save as Draft
+          </Button>
+        </div>
       </form>
   );
 }

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -7,7 +7,7 @@ const { slug } = Astro.params;
 const posts = await getCollection("blog");
 const post = posts.find((p) => p.id === slug);
 
-if (!post) {
+if (!post || post.data.draft) {
   return Astro.redirect("/404");
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Button from "../components/Button";
 const siteTitle = "some.blog.or.whatever";
 
 const posts = (await getCollection("blog"))
+  .filter((p) => !p.data.draft)
   .map((p) => ({
     id: p.id,
     title: p.data.title,


### PR DESCRIPTION
## Summary
This PR adds support for draft blog posts, allowing authors to save posts as drafts before publishing them. Draft posts are stored in the repository but hidden from the public site until explicitly published.

## Key Changes

- **Blog Post Model**: Added `draft` boolean field to `BlogPost` interface and content schema
- **Draft Management**: 
  - Posts can now be created as drafts via the new post form
  - Draft status is persisted in the MDX frontmatter
  - `listPosts()` now reads and returns draft status for each post
- **Publish Workflow**: 
  - New `publishPost()` function to convert draft posts to published by updating the frontmatter
  - New server action `blog.publish` to handle publish requests with authentication
- **Admin UI Updates**:
  - New "Save as Draft" button alongside "Publish" button in the post creation form
  - New `PublishPostButton` component to publish draft posts from the admin dashboard
  - Draft posts are labeled with a "Draft" badge in the post list
  - Publish button only appears for draft posts
- **Public Site**: Draft posts are filtered out from the homepage and individual post pages (404 redirect if accessed directly)

## Implementation Details

- Draft status is read from MDX frontmatter using regex pattern matching on file content
- The `listPosts()` function now fetches full file content to extract draft metadata (previously only returned file listings)
- Publishing updates the frontmatter `draft: true` to `draft: false` and commits the change
- All draft-related operations require authentication

https://claude.ai/code/session_01TEwzhuYYbK82mPkVnFPEt8