### PR TITLE
Add JSX component support to MDX editor with Tooltip and Alert components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Project Guidelines
+
+## Code Style
+
+- Do not use ternary operators. Prefer if statements or early returns for conditional logic.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "tailwindcss": "^3.2.4",
     "tslib": "^2.4.1",
     "typescript": "~5.9.3",
+    "vitest": "^4.1.2",
     "wrangler": "^4.76.0"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
     "@tailwindcss/typography": "^0.5.8",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
@@ -20,6 +22,7 @@
     "autoprefixer": "^10.4.13",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",
+    "jsdom": "^29.0.1",
     "postcss": "^8.4.21",
     "prettier": "^2.8.1",
     "prettier-plugin-tailwindcss": "^0.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2))
       wrangler:
         specifier: ^4.76.0
         version: 4.76.0
@@ -2316,6 +2319,9 @@ packages:
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
@@ -2339,8 +2345,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2453,6 +2465,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
     peerDependencies:
@@ -2546,6 +2587,10 @@ packages:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
     engines: {node: '>=12.0.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -2621,6 +2666,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2997,6 +3046,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -4129,6 +4182,9 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -4151,8 +4207,14 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   static-browser-server@1.0.3:
     resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   strict-event-emitter@0.4.6:
     resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
@@ -4224,6 +4286,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -4235,6 +4300,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4544,6 +4613,41 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -4649,6 +4753,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -7845,6 +7954,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.14': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stitches/core@1.2.8': {}
 
   '@swc/helpers@0.5.20':
@@ -7877,9 +7988,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -8021,6 +8139,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-service': 2.4.28
@@ -8129,6 +8288,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -8282,6 +8443,8 @@ snapshots:
   caniuse-lite@1.0.30001777: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -8710,6 +8873,8 @@ snapshots:
       es5-ext: 0.10.64
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   ext@1.7.0:
     dependencies:
@@ -10374,6 +10539,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -10386,12 +10553,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   static-browser-server@1.0.3:
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       dotenv: 16.6.1
       mime-db: 1.54.0
       outvariant: 1.4.0
+
+  std-env@4.0.0: {}
 
   strict-event-emitter@0.4.6: {}
 
@@ -10492,6 +10663,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyexec@1.0.2: {}
@@ -10500,6 +10673,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10750,6 +10925,31 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(jiti@1.21.7)(yaml@2.8.2)
 
+  vitest@4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
@@ -10856,6 +11056,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,12 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.8
         version: 0.5.19(tailwindcss@3.4.19(yaml@2.8.2))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -72,6 +78,9 @@ importers:
       eslint-config-prettier:
         specifier: ^8.6.0
         version: 8.10.2(eslint@8.57.1)
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       postcss:
         specifier: ^8.4.21
         version: 8.5.8
@@ -101,16 +110,30 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2))
+        version: 4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2))
       wrangler:
         specifier: ^4.76.0
         version: 4.76.0
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.1':
+    resolution: {integrity: sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@astrojs/check@0.9.8':
     resolution: {integrity: sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==}
@@ -263,6 +286,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
@@ -431,6 +458,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -629,6 +692,15 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2333,6 +2405,32 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2555,6 +2653,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -2571,6 +2673,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2627,6 +2732,9 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2797,6 +2905,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2812,6 +2923,10 @@ packages:
   d@1.0.2:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
     engines: {node: '>=0.12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2878,6 +2993,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -3236,6 +3357,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -3259,6 +3384,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3342,6 +3471,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -3362,6 +3494,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3436,6 +3577,10 @@ packages:
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -3650,6 +3795,10 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   miniflare@4.20260317.1:
     resolution: {integrity: sha512-A3csI1HXEIfqe3oscgpoRMHdYlkReQKPH/g5JE53vFSjoM6YIAOGAzyDNeYffwd9oQkPWDj9xER8+vpxei8klA==}
     engines: {node: '>=18.0.0'}
@@ -3781,6 +3930,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -3901,6 +4053,10 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -4039,6 +4195,10 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -4154,6 +4314,10 @@ packages:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -4230,6 +4394,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4264,6 +4432,9 @@ packages:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -4305,6 +4476,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
+
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4312,6 +4490,14 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4381,6 +4567,10 @@ packages:
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -4743,8 +4933,24 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -4797,6 +5003,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -4860,7 +5073,27 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@astrojs/check@0.9.8(prettier@2.8.8)(typescript@5.9.3)':
     dependencies:
@@ -5136,6 +5369,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@capsizecss/unpack@4.0.0':
     dependencies:
@@ -5484,6 +5721,30 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -5612,6 +5873,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7967,6 +8230,38 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.19(yaml@2.8.2)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -8262,6 +8557,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -8276,6 +8573,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -8407,6 +8708,10 @@ snapshots:
   baseline-browser-mapping@2.10.0: {}
 
   before-after-hook@4.0.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
 
@@ -8570,6 +8875,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csso@5.0.5:
@@ -8582,6 +8889,13 @@ snapshots:
     dependencies:
       es5-ext: 0.10.64
       type: 2.7.3
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
@@ -8628,6 +8942,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -9155,6 +9473,12 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -9171,6 +9495,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -9235,6 +9561,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
@@ -9250,6 +9578,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -9303,6 +9657,8 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@11.2.6: {}
+
+  lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9825,6 +10181,8 @@ snapshots:
 
   mime-db@1.54.0: {}
 
+  min-indent@1.0.1: {}
+
   miniflare@4.20260317.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -9966,6 +10324,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -10046,6 +10408,12 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.8.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prismjs@1.30.0: {}
 
@@ -10274,6 +10642,11 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect-metadata@0.2.2: {}
 
   regex-recursion@6.0.2:
@@ -10485,6 +10858,10 @@ snapshots:
 
   sax@1.5.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -10581,6 +10958,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   style-mod@4.1.3: {}
@@ -10620,6 +11001,8 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.5.0
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
 
@@ -10676,11 +11059,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.27: {}
+
+  tldts@7.0.27:
+    dependencies:
+      tldts-core: 7.0.27
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toad-cache@3.7.0: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.27
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -10728,6 +11125,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici@7.24.4: {}
+
+  undici@7.24.7: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -10925,7 +11324,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(jiti@1.21.7)(yaml@2.8.2)
 
-  vitest@4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2)):
+  vitest@4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.2))
@@ -10947,6 +11346,8 @@ snapshots:
       tinyrainbow: 3.1.0
       vite: 7.3.1(jiti@1.21.7)(yaml@2.8.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
 
@@ -11049,7 +11450,23 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-pm-runs@1.1.0: {}
 
@@ -11097,6 +11514,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,7 +15,7 @@ import {
   getOrigin,
 } from "../lib/auth";
 import type { UserRecord } from "../lib/auth";
-import { createPost, postExists, deletePost, publishPost, slugify } from "../lib/blog";
+import { createPost, updatePost, postExists, deletePost, publishPost, slugify } from "../lib/blog";
 import type { BlogPost } from "../lib/blog";
 import { env } from "cloudflare:workers";
 
@@ -52,6 +52,35 @@ export const server = {
 
         const post: BlogPost = { slug, ...input };
         await createPost(post);
+        return { slug };
+      },
+    }),
+
+    update: defineAction({
+      accept: "json",
+      input: z.object({
+        slug: z.string().min(1),
+        sha: z.string().min(1),
+        title: z.string().min(1),
+        author: z.string().min(1),
+        date: z.string().min(1),
+        description: z.string().min(1),
+        tags: z.array(z.string()),
+        categories: z.array(z.string()),
+        content: z.string().min(1),
+        draft: z.boolean().optional().default(false),
+      }),
+      handler: async (input, context) => {
+        if (!(await isAuthenticated(context))) {
+          throw new ActionError({
+            code: "FORBIDDEN",
+            message: "Not authenticated",
+          });
+        }
+
+        const { slug, sha, ...rest } = input;
+        const post = { slug, ...rest };
+        await updatePost(post, sha);
         return { slug };
       },
     }),

--- a/src/lib/blog.test.ts
+++ b/src/lib/blog.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { parseMdxContent } from "./blog";
+
+const DOUBLE_QUOTED = `---
+author: "John Pangalos"
+title: "obligatory.ai.post"
+date: "April 2, 2026"
+description: "You are absolutely right, I have updated my blog again."
+tags: ["bloging", "astro", "ai"]
+categories: ["web", "ai"]
+draft: true
+---
+
+## getting.sloppy
+
+Hello my name is John and I have a problem.
+`;
+
+const SINGLE_QUOTED_DESC = `---
+author: "John Pangalos"
+title: "the.winds.of.2025"
+date: "January 19, 2025"
+description: 'Writing pace be damned! Sometimes it''s better to not write anything. Like a Donald Trump once said, "If you don''t have something nice to say, don''t say anything at all"'
+tags: ["Game of Thrones", "writing", "jokes"]
+categories: ["books"]
+---
+
+Some content here.
+`;
+
+const WITH_IMPORTS = `---
+author: "John Pangalos"
+title: "looking.svelte"
+date: "May 2, 2021"
+description: "A post about Svelte."
+tags: ["web-dev", "svelte"]
+categories: ["game-development"]
+---
+
+import Tooltip from "../../components/Tooltip.tsx";
+import Link from "../../components/Link.tsx";
+
+Some MDX content with <Tooltip client:visible main="hi" hover="there" />.
+`;
+
+const PUBLISHED = `---
+author: "John Pangalos"
+title: "published.post"
+date: "March 1, 2025"
+description: "A published post."
+tags: ["test"]
+categories: ["misc"]
+draft: false
+---
+
+Published content.
+`;
+
+describe("parseMdxContent", () => {
+  it("parses double-quoted frontmatter fields", () => {
+    const result = parseMdxContent(DOUBLE_QUOTED, "obligatory-ai-post", "abc123");
+
+    expect(result).not.toBeNull();
+    expect(result!.slug).toBe("obligatory-ai-post");
+    expect(result!.sha).toBe("abc123");
+    expect(result!.author).toBe("John Pangalos");
+    expect(result!.title).toBe("obligatory.ai.post");
+    expect(result!.date).toBe("April 2, 2026");
+    expect(result!.description).toBe(
+      "You are absolutely right, I have updated my blog again.",
+    );
+    expect(result!.draft).toBe(true);
+  });
+
+  it("parses tags and categories arrays", () => {
+    const result = parseMdxContent(DOUBLE_QUOTED, "test", "sha1");
+
+    expect(result!.tags).toEqual(["bloging", "astro", "ai"]);
+    expect(result!.categories).toEqual(["web", "ai"]);
+  });
+
+  it("parses single-quoted description with escaped quotes", () => {
+    const result = parseMdxContent(SINGLE_QUOTED_DESC, "the-winds-of-2025", "sha2");
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("the.winds.of.2025");
+    expect(result!.description).toBe(
+      `Writing pace be damned! Sometimes it's better to not write anything. Like a Donald Trump once said, "If you don't have something nice to say, don't say anything at all"`,
+    );
+    expect(result!.tags).toEqual(["Game of Thrones", "writing", "jokes"]);
+  });
+
+  it("separates content from frontmatter", () => {
+    const result = parseMdxContent(DOUBLE_QUOTED, "test", "sha1");
+
+    expect(result!.content).toBe(
+      "## getting.sloppy\n\nHello my name is John and I have a problem.",
+    );
+  });
+
+  it("preserves import statements in content", () => {
+    const result = parseMdxContent(WITH_IMPORTS, "looking-svelte", "sha3");
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('import Tooltip from');
+    expect(result!.content).toContain('<Tooltip client:visible');
+  });
+
+  it("parses draft: false as not draft", () => {
+    const result = parseMdxContent(PUBLISHED, "published-post", "sha4");
+
+    expect(result!.draft).toBe(false);
+  });
+
+  it("defaults draft to false when not specified", () => {
+    const result = parseMdxContent(SINGLE_QUOTED_DESC, "test", "sha5");
+
+    expect(result!.draft).toBe(false);
+  });
+
+  it("returns null for invalid frontmatter", () => {
+    const result = parseMdxContent("no frontmatter here", "test", "sha6");
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -271,6 +271,88 @@ export async function publishPost(slug: string): Promise<void> {
   });
 }
 
+export async function getPost(
+  slug: string,
+): Promise<(BlogPost & { sha: string }) | null> {
+  const octokit = getOctokit();
+  const filePath = `${CONTENT_PATH}/${slug}.mdx`;
+
+  try {
+    const { data } = await octokit.repos.getContent({
+      owner: GITHUB_REPO_OWNER,
+      repo: GITHUB_REPO_NAME,
+      path: filePath,
+    });
+
+    if (Array.isArray(data) || !("content" in data) || !data.content) {
+      return null;
+    }
+
+    const raw = new TextDecoder().decode(
+      Uint8Array.from(atob(data.content.replace(/\n/g, "")), (c) =>
+        c.charCodeAt(0),
+      ),
+    );
+    const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+    if (!fmMatch) return null;
+
+    const fm = fmMatch[1];
+    const content = fmMatch[2].trim();
+
+    const get = (key: string) => {
+      const m = fm.match(new RegExp(`^${key}:\\s*"(.*)"\s*$`, "m"));
+      return m ? m[1] : "";
+    };
+
+    const getArray = (key: string): string[] => {
+      const m = fm.match(new RegExp(`^${key}:\\s*\\[(.*)\\]\\s*$`, "m"));
+      if (!m) return [];
+      return m[1]
+        .split(",")
+        .map((s) => s.trim().replace(/^"|"$/g, ""))
+        .filter(Boolean);
+    };
+
+    return {
+      slug,
+      author: get("author"),
+      title: get("title"),
+      date: get("date"),
+      description: get("description"),
+      tags: getArray("tags"),
+      categories: getArray("categories"),
+      draft: /^draft:\s*true\s*$/m.test(fm),
+      content,
+      sha: data.sha,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function updatePost(
+  post: BlogPost,
+  sha: string,
+): Promise<void> {
+  const octokit = getOctokit();
+  const filePath = `${CONTENT_PATH}/${post.slug}.mdx`;
+  const fileContent = buildMdxContent(post);
+  const encodedContent = btoa(
+    new TextEncoder()
+      .encode(fileContent)
+      .reduce((acc, byte) => acc + String.fromCharCode(byte), ""),
+  );
+
+  await octokit.repos.createOrUpdateFileContents({
+    owner: GITHUB_REPO_OWNER,
+    repo: GITHUB_REPO_NAME,
+    path: filePath,
+    message: `Update blog post: ${post.title}`,
+    content: encodedContent,
+    sha,
+  });
+}
+
 export async function postExists(
   slug: string,
 ): Promise<boolean> {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -111,6 +111,13 @@ export function slugify(title: string): string {
     .replace(/^-|-$/g, "");
 }
 
+function addAstroDirectives(content: string): string {
+  return content.replace(
+    /<Tooltip(?![^>]*client:visible)/g,
+    "<Tooltip client:visible",
+  );
+}
+
 function buildMdxContent(post: Omit<BlogPost, "slug">): string {
   const frontmatter = [
     "---",
@@ -124,7 +131,9 @@ function buildMdxContent(post: Omit<BlogPost, "slug">): string {
     "---",
   ].join("\n");
 
-  return `${frontmatter}\n\n${post.content}\n`;
+  const content = addAstroDirectives(post.content);
+
+  return `${frontmatter}\n\n${content}\n`;
 }
 
 export async function createPost(

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -300,7 +300,7 @@ export async function getPost(
     const content = fmMatch[2].trim();
 
     const get = (key: string) => {
-      const m = fm.match(new RegExp(`^${key}:\\s*"(.*)"\s*$`, "m"));
+      const m = fm.match(new RegExp(`^${key}:\\s*"(.*)"\\s*$`, "m"));
       return m ? m[1] : "";
     };
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -291,7 +291,8 @@ export function parseMdxContent(
     if (sq) return sq[1].replace(/''/g, "'");
     // Match unquoted: key: value
     const uq = fm.match(new RegExp(`^${key}:\\s*(.+?)\\s*$`, "m"));
-    return uq ? uq[1] : "";
+    if (uq) return uq[1];
+    return "";
   };
 
   const getArray = (key: string): string[] => {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -271,6 +271,52 @@ export async function publishPost(slug: string): Promise<void> {
   });
 }
 
+export function parseMdxContent(
+  raw: string,
+  slug: string,
+  sha: string,
+): (BlogPost & { sha: string }) | null {
+  const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!fmMatch) return null;
+
+  const fm = fmMatch[1];
+  const content = fmMatch[2].trim();
+
+  const get = (key: string) => {
+    // Match double-quoted: key: "value"
+    const dq = fm.match(new RegExp(`^${key}:\\s*"(.*)"\\s*$`, "m"));
+    if (dq) return dq[1];
+    // Match single-quoted: key: 'value' (with '' escape for literal ')
+    const sq = fm.match(new RegExp(`^${key}:\\s*'(.*)'\\s*$`, "m"));
+    if (sq) return sq[1].replace(/''/g, "'");
+    // Match unquoted: key: value
+    const uq = fm.match(new RegExp(`^${key}:\\s*(.+?)\\s*$`, "m"));
+    return uq ? uq[1] : "";
+  };
+
+  const getArray = (key: string): string[] => {
+    const m = fm.match(new RegExp(`^${key}:\\s*\\[(.*)\\]\\s*$`, "m"));
+    if (!m) return [];
+    return m[1]
+      .split(",")
+      .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+      .filter(Boolean);
+  };
+
+  return {
+    slug,
+    author: get("author"),
+    title: get("title"),
+    date: get("date"),
+    description: get("description"),
+    tags: getArray("tags"),
+    categories: getArray("categories"),
+    draft: /^draft:\s*true\s*$/m.test(fm),
+    content,
+    sha,
+  };
+}
+
 export async function getPost(
   slug: string,
 ): Promise<(BlogPost & { sha: string }) | null> {
@@ -293,38 +339,8 @@ export async function getPost(
         c.charCodeAt(0),
       ),
     );
-    const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
-    if (!fmMatch) return null;
 
-    const fm = fmMatch[1];
-    const content = fmMatch[2].trim();
-
-    const get = (key: string) => {
-      const m = fm.match(new RegExp(`^${key}:\\s*"(.*)"\\s*$`, "m"));
-      return m ? m[1] : "";
-    };
-
-    const getArray = (key: string): string[] => {
-      const m = fm.match(new RegExp(`^${key}:\\s*\\[(.*)\\]\\s*$`, "m"));
-      if (!m) return [];
-      return m[1]
-        .split(",")
-        .map((s) => s.trim().replace(/^"|"$/g, ""))
-        .filter(Boolean);
-    };
-
-    return {
-      slug,
-      author: get("author"),
-      title: get("title"),
-      date: get("date"),
-      description: get("description"),
-      tags: getArray("tags"),
-      categories: getArray("categories"),
-      draft: /^draft:\s*true\s*$/m.test(fm),
-      content,
-      sha: data.sha,
-    };
+    return parseMdxContent(raw, slug, data.sha);
   } catch {
     return null;
   }

--- a/src/pages/admin/edit/[slug].astro
+++ b/src/pages/admin/edit/[slug].astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { isAuthenticated } from "../../../lib/auth";
+import { getPost } from "../../../lib/blog";
+import PostForm from "../new/_components/PostForm";
+
+if (!(await isAuthenticated(Astro))) {
+  return Astro.redirect("/admin/login");
+}
+
+const { slug } = Astro.params;
+const post = slug ? await getPost(slug) : null;
+
+if (!post) {
+  return Astro.redirect("/admin");
+}
+---
+
+<BaseLayout title="Edit Post">
+  <div class="mt-16">
+    <div class="flex items-center justify-between">
+      <h1 class="font-display text-3xl font-bold">Edit Post</h1>
+      <a
+        href="/admin"
+        class="rounded bg-stone-200 px-3 py-1 text-sm hover:bg-stone-300 dark:bg-stone-700 dark:hover:bg-stone-600"
+      >
+        Back
+      </a>
+    </div>
+
+    <PostForm
+      client:load
+      initialData={{
+        slug: post.slug,
+        sha: post.sha,
+        title: post.title,
+        author: post.author,
+        date: post.date,
+        description: post.description,
+        tags: post.tags.join(", "),
+        categories: post.categories.join(", "),
+        content: post.content,
+        draft: post.draft,
+      }}
+    />
+  </div>
+</BaseLayout>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -47,7 +47,7 @@ try {
           <h2 class="font-display text-xl font-bold">Blog Posts</h2>
           <ul class="mt-4 space-y-3">
             {posts.map((post) => (
-              <li class="flex items-center justify-between rounded border border-stone-200 p-3 dark:border-stone-700">
+              <li class="flex flex-col gap-3 rounded border border-stone-200 p-4 dark:border-stone-700 sm:flex-row sm:items-center sm:justify-between">
                 <div class="flex items-center gap-2">
                   <a
                     href={`/blog/${post.slug}`}
@@ -62,6 +62,12 @@ try {
                   )}
                 </div>
                 <div class="flex gap-2">
+                  <a
+                    href={`/admin/edit/${post.slug}`}
+                    class="rounded bg-fuchsia-700 px-2 py-1 text-xs text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
+                  >
+                    Edit
+                  </a>
                   {post.draft && (
                     <PublishPostButton client:load slug={post.slug} />
                   )}

--- a/src/pages/admin/new/_components/MdxEditorField.tsx
+++ b/src/pages/admin/new/_components/MdxEditorField.tsx
@@ -12,6 +12,7 @@ import {
   codeBlockPlugin,
   codeMirrorPlugin,
   toolbarPlugin,
+  jsxPlugin,
   BoldItalicUnderlineToggles,
   BlockTypeSelect,
   CreateLink,
@@ -20,9 +21,45 @@ import {
   ListsToggle,
   UndoRedo,
   InsertCodeBlock,
+  insertJsx$,
+  usePublisher,
   type MDXEditorMethods,
 } from "@mdxeditor/editor";
 import "@mdxeditor/editor/style.css";
+import { blogJsxComponentDescriptors } from "./jsxComponentDescriptors";
+
+function InsertComponentButton() {
+  const insertJsx = usePublisher(insertJsx$);
+
+  return (
+    <select
+      className="h-8 rounded border border-stone-300 bg-white px-2 text-sm dark:border-stone-600 dark:bg-stone-800"
+      value=""
+      onChange={(e) => {
+        const value = e.target.value;
+        if (value === "Tooltip") {
+          insertJsx({
+            kind: "text",
+            name: "Tooltip",
+            props: { main: "text", hover: "tooltip" },
+          });
+        } else if (value === "NerdAlert") {
+          insertJsx({ kind: "flow", name: "NerdAlert", props: {} });
+        } else if (value === "SpoilerAlert") {
+          insertJsx({ kind: "flow", name: "SpoilerAlert", props: {} });
+        }
+        e.target.value = "";
+      }}
+    >
+      <option value="" disabled>
+        + Component
+      </option>
+      <option value="Tooltip">Tooltip</option>
+      <option value="NerdAlert">Nerd Alert</option>
+      <option value="SpoilerAlert">Spoiler Alert</option>
+    </select>
+  );
+}
 
 export default function MdxEditorField({
   name,
@@ -52,6 +89,7 @@ export default function MdxEditorField({
             linkPlugin(),
             linkDialogPlugin(),
             tablePlugin(),
+            jsxPlugin({ jsxComponentDescriptors: blogJsxComponentDescriptors }),
             codeBlockPlugin({ defaultCodeBlockLanguage: "" }),
             codeMirrorPlugin({
               codeBlockLanguages: {
@@ -80,6 +118,7 @@ export default function MdxEditorField({
                   <InsertTable />
                   <InsertThematicBreak />
                   <InsertCodeBlock />
+                  <InsertComponentButton />
                 </>
               ),
             }),

--- a/src/pages/admin/new/_components/PostForm.test.tsx
+++ b/src/pages/admin/new/_components/PostForm.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import PostForm, { type PostFormData } from "./PostForm";
+
+// Mock astro:actions
+vi.mock("astro:actions", () => ({
+  actions: {
+    blog: {
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+// Mock MDXEditor since it requires browser APIs not available in jsdom
+vi.mock("./MdxEditorField", () => ({
+  default: ({ name, defaultValue }: { name: string; defaultValue?: string }) => (
+    <textarea data-testid="mdx-editor" name={name} defaultValue={defaultValue} />
+  ),
+}));
+
+afterEach(cleanup);
+
+function getInput(name: string): HTMLInputElement | HTMLTextAreaElement {
+  return document.querySelector(`[name="${name}"]`)!;
+}
+
+const sampleData: PostFormData = {
+  slug: "test-post",
+  sha: "abc123",
+  title: "Test Post Title",
+  author: "John Pangalos",
+  date: "April 2, 2026",
+  description: "A test description for the post.",
+  tags: "web, javascript",
+  categories: "web",
+  content: "## Hello\n\nSome content here.",
+  draft: true,
+};
+
+describe("PostForm", () => {
+  describe("edit mode (with initialData)", () => {
+    it("populates all fields with initial data", () => {
+      render(<PostForm initialData={sampleData} />);
+
+      expect(getInput("title")).toHaveValue("Test Post Title");
+      expect(getInput("author")).toHaveValue("John Pangalos");
+      expect(getInput("date")).toHaveValue("April 2, 2026");
+      expect(getInput("description")).toHaveValue("A test description for the post.");
+      expect(getInput("tags")).toHaveValue("web, javascript");
+      expect(getInput("categories")).toHaveValue("web");
+    });
+
+    it("makes title read-only in edit mode", () => {
+      render(<PostForm initialData={sampleData} />);
+
+      expect(getInput("title")).toHaveAttribute("readonly");
+    });
+
+    it("passes content to MDX editor", () => {
+      render(<PostForm initialData={sampleData} />);
+
+      expect(getInput("content")).toHaveValue("## Hello\n\nSome content here.");
+    });
+
+    it("shows Update button instead of Publish", () => {
+      render(<PostForm initialData={sampleData} />);
+
+      const buttons = screen.getAllByRole("button");
+      const buttonTexts = buttons.map((b) => b.textContent);
+      expect(buttonTexts).toContain("Update");
+      expect(buttonTexts).not.toContain("Publish");
+    });
+  });
+
+  describe("create mode (no initialData)", () => {
+    it("renders empty fields with author default", () => {
+      render(<PostForm />);
+
+      expect(getInput("title")).toHaveValue("");
+      expect(getInput("title")).not.toHaveAttribute("readonly");
+      expect(getInput("author")).toHaveValue("John Pangalos");
+      expect(getInput("date")).toHaveValue("");
+      expect(getInput("description")).toHaveValue("");
+    });
+
+    it("shows Publish button", () => {
+      render(<PostForm />);
+
+      const buttons = screen.getAllByRole("button");
+      const buttonTexts = buttons.map((b) => b.textContent);
+      expect(buttonTexts).toContain("Publish");
+      expect(buttonTexts).not.toContain("Update");
+    });
+  });
+});

--- a/src/pages/admin/new/_components/PostForm.tsx
+++ b/src/pages/admin/new/_components/PostForm.tsx
@@ -103,75 +103,64 @@ export default function PostForm({
         onSubmit={(e) => handleSubmit(e, false)}
         className="mt-8 space-y-4"
       >
-        <TextField>
+        <TextField defaultValue={initialData?.title} isReadOnly={isEditing} isRequired>
           <Label className="block text-sm font-bold">Title</Label>
           <Input
             type="text"
             name="title"
-            required
-            readOnly={isEditing}
-            defaultValue={initialData?.title}
             className={`${inputClasses}${isEditing ? " opacity-60" : ""}`}
             placeholder="the.post.title"
           />
         </TextField>
 
-        <TextField>
+        <TextField defaultValue={initialData?.author ?? "John Pangalos"} isRequired>
           <Label className="block text-sm font-bold">Author</Label>
           <Input
             type="text"
             name="author"
-            required
-            defaultValue={initialData?.author ?? "John Pangalos"}
             className={inputClasses}
           />
         </TextField>
 
-        <TextField>
+        <TextField defaultValue={initialData?.date} isRequired>
           <Label className="block text-sm font-bold">Date</Label>
           <Input
             type="text"
             name="date"
-            required
-            defaultValue={initialData?.date}
             className={inputClasses}
             placeholder="March 20, 2026"
           />
         </TextField>
 
-        <TextField>
+        <TextField defaultValue={initialData?.description} isRequired>
           <Label className="block text-sm font-bold">Description</Label>
           <TextArea
             name="description"
-            required
             rows={2}
-            defaultValue={initialData?.description}
             className={inputClasses}
             placeholder="A short description of the post..."
           />
         </TextField>
 
-        <TextField>
+        <TextField defaultValue={initialData?.tags}>
           <Label className="block text-sm font-bold">
             Tags (comma-separated)
           </Label>
           <Input
             type="text"
             name="tags"
-            defaultValue={initialData?.tags}
             className={inputClasses}
             placeholder="web, javascript, blogging"
           />
         </TextField>
 
-        <TextField>
+        <TextField defaultValue={initialData?.categories}>
           <Label className="block text-sm font-bold">
             Categories (comma-separated)
           </Label>
           <Input
             type="text"
             name="categories"
-            defaultValue={initialData?.categories}
             className={inputClasses}
             placeholder="web"
           />

--- a/src/pages/admin/new/_components/PostForm.tsx
+++ b/src/pages/admin/new/_components/PostForm.tsx
@@ -9,7 +9,26 @@ import {
 } from "react-aria-components";
 import MdxEditorField from "./MdxEditorField";
 
-export default function NewPostForm() {
+export interface PostFormData {
+  slug: string;
+  sha: string;
+  title: string;
+  author: string;
+  date: string;
+  description: string;
+  tags: string;
+  categories: string;
+  content: string;
+  draft: boolean;
+}
+
+export default function PostForm({
+  initialData,
+}: {
+  initialData?: PostFormData;
+}) {
+  const isEditing = !!initialData;
+
   const [status, setStatus] = useState<{
     message: string;
     type: "idle" | "loading" | "success" | "error";
@@ -22,7 +41,7 @@ export default function NewPostForm() {
     e.preventDefault();
 
     setStatus({
-      message: draft ? "Saving draft..." : "Publishing...",
+      message: draft ? "Saving draft..." : isEditing ? "Updating..." : "Publishing...",
       type: "loading",
     });
 
@@ -39,7 +58,7 @@ export default function NewPostForm() {
       .map((c) => c.trim())
       .filter(Boolean);
 
-    const { error } = await actions.blog.create({
+    const payload = {
       title: formData.get("title") as string,
       author: formData.get("author") as string,
       date: formData.get("date") as string,
@@ -48,7 +67,15 @@ export default function NewPostForm() {
       categories,
       content: formData.get("content") as string,
       draft,
-    });
+    };
+
+    const { error } = isEditing
+      ? await actions.blog.update({
+          slug: initialData.slug,
+          sha: initialData.sha,
+          ...payload,
+        })
+      : await actions.blog.create(payload);
 
     if (error) {
       setStatus({ message: `Error: ${error.message}`, type: "error" });
@@ -58,7 +85,9 @@ export default function NewPostForm() {
     setStatus({
       message: draft
         ? "Draft saved to repo!"
-        : "Post committed to repo! It will be live after the site rebuilds.",
+        : isEditing
+          ? "Post updated! It will be live after the site rebuilds."
+          : "Post committed to repo! It will be live after the site rebuilds.",
       type: "success",
     });
     setTimeout(() => {
@@ -80,7 +109,9 @@ export default function NewPostForm() {
             type="text"
             name="title"
             required
-            className={inputClasses}
+            readOnly={isEditing}
+            defaultValue={initialData?.title}
+            className={`${inputClasses}${isEditing ? " opacity-60" : ""}`}
             placeholder="the.post.title"
           />
         </TextField>
@@ -91,7 +122,7 @@ export default function NewPostForm() {
             type="text"
             name="author"
             required
-            defaultValue="John Pangalos"
+            defaultValue={initialData?.author ?? "John Pangalos"}
             className={inputClasses}
           />
         </TextField>
@@ -102,6 +133,7 @@ export default function NewPostForm() {
             type="text"
             name="date"
             required
+            defaultValue={initialData?.date}
             className={inputClasses}
             placeholder="March 20, 2026"
           />
@@ -113,6 +145,7 @@ export default function NewPostForm() {
             name="description"
             required
             rows={2}
+            defaultValue={initialData?.description}
             className={inputClasses}
             placeholder="A short description of the post..."
           />
@@ -125,6 +158,7 @@ export default function NewPostForm() {
           <Input
             type="text"
             name="tags"
+            defaultValue={initialData?.tags}
             className={inputClasses}
             placeholder="web, javascript, blogging"
           />
@@ -137,6 +171,7 @@ export default function NewPostForm() {
           <Input
             type="text"
             name="categories"
+            defaultValue={initialData?.categories}
             className={inputClasses}
             placeholder="web"
           />
@@ -145,7 +180,10 @@ export default function NewPostForm() {
         <div>
           <label className="block text-sm font-bold">Content (MDX)</label>
           <div className="mt-1">
-            <MdxEditorField name="content" />
+            <MdxEditorField
+              name="content"
+              defaultValue={initialData?.content}
+            />
           </div>
         </div>
 
@@ -168,7 +206,7 @@ export default function NewPostForm() {
             type="submit"
             className="rounded bg-fuchsia-700 px-4 py-2 font-bold text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
           >
-            Publish
+            {isEditing ? "Update" : "Publish"}
           </Button>
           <Button
             type="button"

--- a/src/pages/admin/new/_components/PostForm.tsx
+++ b/src/pages/admin/new/_components/PostForm.tsx
@@ -22,6 +22,24 @@ export interface PostFormData {
   draft: boolean;
 }
 
+function getLoadingMessage(draft: boolean, isEditing: boolean) {
+  if (draft) return "Saving draft...";
+  if (isEditing) return "Updating...";
+  return "Publishing...";
+}
+
+function getSuccessMessage(draft: boolean, isEditing: boolean) {
+  if (draft) return "Draft saved to repo!";
+  if (isEditing) return "Post updated! It will be live after the site rebuilds.";
+  return "Post committed to repo! It will be live after the site rebuilds.";
+}
+
+function getStatusColorClass(type: string) {
+  if (type === "error") return "text-red-600 dark:text-red-400";
+  if (type === "success") return "text-green-600 dark:text-green-400";
+  return "text-stone-500";
+}
+
 export default function PostForm({
   initialData,
 }: {
@@ -41,7 +59,7 @@ export default function PostForm({
     e.preventDefault();
 
     setStatus({
-      message: draft ? "Saving draft..." : isEditing ? "Updating..." : "Publishing...",
+      message: getLoadingMessage(draft, isEditing),
       type: "loading",
     });
 
@@ -69,25 +87,24 @@ export default function PostForm({
       draft,
     };
 
-    const { error } = isEditing
-      ? await actions.blog.update({
-          slug: initialData.slug,
-          sha: initialData.sha,
-          ...payload,
-        })
-      : await actions.blog.create(payload);
+    let result;
+    if (isEditing) {
+      result = await actions.blog.update({
+        slug: initialData.slug,
+        sha: initialData.sha,
+        ...payload,
+      });
+    } else {
+      result = await actions.blog.create(payload);
+    }
 
-    if (error) {
-      setStatus({ message: `Error: ${error.message}`, type: "error" });
+    if (result.error) {
+      setStatus({ message: `Error: ${result.error.message}`, type: "error" });
       return;
     }
 
     setStatus({
-      message: draft
-        ? "Draft saved to repo!"
-        : isEditing
-          ? "Post updated! It will be live after the site rebuilds."
-          : "Post committed to repo! It will be live after the site rebuilds.",
+      message: getSuccessMessage(draft, isEditing),
       type: "success",
     });
     setTimeout(() => {
@@ -97,6 +114,14 @@ export default function PostForm({
 
   const inputClasses =
     "mt-1 w-full rounded border border-stone-300 bg-white px-3 py-2 text-stone-900 dark:border-stone-600 dark:bg-stone-800 dark:text-white";
+
+  let titleClassName = inputClasses;
+  if (isEditing) {
+    titleClassName += " opacity-60";
+  }
+
+  const authorDefault = initialData?.author || "John Pangalos";
+  const submitLabel = isEditing ? "Update" : "Publish";
 
   return (
       <form
@@ -108,12 +133,12 @@ export default function PostForm({
           <Input
             type="text"
             name="title"
-            className={`${inputClasses}${isEditing ? " opacity-60" : ""}`}
+            className={titleClassName}
             placeholder="the.post.title"
           />
         </TextField>
 
-        <TextField defaultValue={initialData?.author ?? "John Pangalos"} isRequired>
+        <TextField defaultValue={authorDefault} isRequired>
           <Label className="block text-sm font-bold">Author</Label>
           <Input
             type="text"
@@ -177,15 +202,7 @@ export default function PostForm({
         </div>
 
         {status.type !== "idle" && (
-          <div
-            className={`text-sm ${
-              status.type === "error"
-                ? "text-red-600 dark:text-red-400"
-                : status.type === "success"
-                  ? "text-green-600 dark:text-green-400"
-                  : "text-stone-500"
-            }`}
-          >
+          <div className={`text-sm ${getStatusColorClass(status.type)}`}>
             {status.message}
           </div>
         )}
@@ -195,7 +212,7 @@ export default function PostForm({
             type="submit"
             className="rounded bg-fuchsia-700 px-4 py-2 font-bold text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
           >
-            {isEditing ? "Update" : "Publish"}
+            {submitLabel}
           </Button>
           <Button
             type="button"

--- a/src/pages/admin/new/_components/jsxComponentDescriptors.tsx
+++ b/src/pages/admin/new/_components/jsxComponentDescriptors.tsx
@@ -1,0 +1,76 @@
+import type { JsxComponentDescriptor, JsxEditorProps } from "@mdxeditor/editor";
+import { GenericJsxEditor } from "@mdxeditor/editor";
+
+function NerdAlertEditor() {
+  const stripeStyle: React.CSSProperties = {
+    backgroundImage:
+      "repeating-linear-gradient(120deg, #facc15 0, #facc15 30px, #374151 30px, #374151 60px)",
+  };
+
+  return (
+    <div
+      className="flex w-full justify-center py-6"
+      style={stripeStyle}
+      contentEditable={false}
+    >
+      <div className="flex items-center justify-center border-4 border-black bg-white px-4 py-2">
+        <span className="text-xl font-medium text-black">NERD ALERT</span>
+      </div>
+    </div>
+  );
+}
+
+function SpoilerAlertEditor() {
+  const stripeStyle: React.CSSProperties = {
+    backgroundImage:
+      "repeating-linear-gradient(120deg, #f97316 0, #f97316 30px, #374151 30px, #374151 60px)",
+  };
+
+  return (
+    <div
+      className="flex w-full justify-center py-6"
+      style={stripeStyle}
+      contentEditable={false}
+    >
+      <div className="flex items-center justify-center border-4 border-black bg-white px-4 py-2">
+        <span className="text-xl font-medium text-black">SPOILER ALERT</span>
+      </div>
+    </div>
+  );
+}
+
+export const blogJsxComponentDescriptors: JsxComponentDescriptor[] = [
+  {
+    name: "Tooltip",
+    kind: "text",
+    source: "../../components/Tooltip.tsx",
+    defaultExport: true,
+    props: [
+      { name: "main", type: "string", required: true },
+      { name: "hover", type: "string", required: true },
+      { name: "to", type: "string" },
+    ],
+    hasChildren: false,
+    Editor: (props: JsxEditorProps) => (
+      <GenericJsxEditor {...props} />
+    ),
+  },
+  {
+    name: "NerdAlert",
+    kind: "flow",
+    source: "../../components/NerdAlert.tsx",
+    defaultExport: true,
+    props: [],
+    hasChildren: false,
+    Editor: NerdAlertEditor,
+  },
+  {
+    name: "SpoilerAlert",
+    kind: "flow",
+    source: "../../components/SpoilerAlert.tsx",
+    defaultExport: true,
+    props: [],
+    hasChildren: false,
+    Editor: SpoilerAlertEditor,
+  },
+];

--- a/src/pages/admin/new/index.astro
+++ b/src/pages/admin/new/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { isAuthenticated } from "../../../lib/auth";
-import NewPostForm from "./_components/NewPostForm";
+import PostForm from "./_components/PostForm";
 
 if (!(await isAuthenticated(Astro))) {
   return Astro.redirect("/admin/login");
@@ -20,6 +20,6 @@ if (!(await isAuthenticated(Astro))) {
       </a>
     </div>
 
-    <NewPostForm client:load />
+    <PostForm client:load />
   </div>
 </BaseLayout>

--- a/src/test/__mocks__/astro-actions.ts
+++ b/src/test/__mocks__/astro-actions.ts
@@ -1,0 +1,6 @@
+export const actions = {
+  blog: {
+    create: async () => ({ data: { slug: "test" } }),
+    update: async () => ({ data: { slug: "test" } }),
+  },
+};

--- a/src/test/__mocks__/cloudflare-workers.ts
+++ b/src/test/__mocks__/cloudflare-workers.ts
@@ -1,0 +1,1 @@
+export const env: Record<string, string> = {};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    alias: {
+      "cloudflare:workers": new URL(
+        "./src/test/__mocks__/cloudflare-workers.ts",
+        import.meta.url,
+      ).pathname,
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,9 +2,15 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
     alias: {
       "cloudflare:workers": new URL(
         "./src/test/__mocks__/cloudflare-workers.ts",
+        import.meta.url,
+      ).pathname,
+      "astro:actions": new URL(
+        "./src/test/__mocks__/astro-actions.ts",
         import.meta.url,
       ).pathname,
     },


### PR DESCRIPTION
## Summary
This PR adds support for inserting custom JSX components (Tooltip, NerdAlert, and SpoilerAlert) directly into blog posts through the MDX editor interface.

## Key Changes
- **New component descriptors file** (`jsxComponentDescriptors.tsx`): Defines three JSX components available in the editor:
  - `Tooltip`: A text-kind component with configurable main text, hover text, and optional link
  - `NerdAlert`: A flow component with yellow/gray striped alert styling
  - `SpoilerAlert`: A flow component with orange/gray striped alert styling

- **Enhanced MDX editor** (`MdxEditorField.tsx`):
  - Integrated `jsxPlugin` with the custom component descriptors
  - Added `InsertComponentButton` dropdown to the toolbar for easy component insertion
  - Dropdown provides quick access to insert Tooltip, NerdAlert, and SpoilerAlert components with sensible defaults

- **Astro directive handling** (`blog.ts`):
  - Added `addAstroDirectives()` function to automatically inject `client:visible` directive to Tooltip components
  - Ensures Tooltip components are properly hydrated in the Astro build output

## Implementation Details
- Alert components use repeating linear gradients for distinctive striped backgrounds
- Component insertion uses the MDX editor's `insertJsx$` publisher pattern
- Tooltip defaults to sample text ("text" and "tooltip") to guide users
- Alert components have no configurable props and are ready to use immediately

https://claude.ai/code/session_01RgXnXpkjG1GCJZzJgceD31