### PR TITLE
Add authentication check for draft blog posts

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -4,10 +4,11 @@ import BaseLayout from "./BaseLayout.astro";
 interface Props {
   title: string;
   date: string;
+  draft?: boolean;
 }
 
 const siteTitle = "some.blog.or.whatever";
-const { title, date } = Astro.props;
+const { title, date, draft } = Astro.props;
 ---
 
 <BaseLayout title={`${title} - ${siteTitle}`}>
@@ -15,6 +16,11 @@ const { title, date } = Astro.props;
     class="prose prose-slate prose-headings:font-display pt-10 pb-20 dark:prose-invert lg:prose-lg prose-headings:font-bold"
   >
     <article>
+      {draft && (
+        <div class="mb-4 rounded-md border border-amber-400 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 dark:border-amber-600 dark:bg-amber-950 dark:text-amber-200">
+          Draft &mdash; this post is not published
+        </div>
+      )}
       <h1 class="!mb-0 pb-2">{title}</h1>
       <p class="!m-0 pb-1 font-bold">{date}</p>
       <slot />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,19 +1,27 @@
 ---
 import { getCollection, render } from "astro:content";
 import BlogLayout from "../../layouts/BlogLayout.astro";
+import { isAuthenticated } from "../../lib/auth";
 
 const { slug } = Astro.params;
 
 const posts = await getCollection("blog");
 const post = posts.find((p) => p.id === slug);
 
-if (!post || post.data.draft) {
+if (!post) {
   return Astro.redirect("/404");
+}
+
+if (post.data.draft) {
+  const isAdmin = await isAuthenticated(Astro);
+  if (!isAdmin) {
+    return Astro.redirect("/404");
+  }
 }
 
 const { Content } = await render(post);
 ---
 
-<BlogLayout title={post.data.title} date={post.data.date}>
+<BlogLayout title={post.data.title} date={post.data.date} draft={post.data.draft}>
   <Content />
 </BlogLayout>


### PR DESCRIPTION
## Summary
This PR adds authentication-based access control for draft blog posts. Draft posts are now only visible to authenticated users (admins), while remaining hidden from public visitors.

## Key Changes
- **Authentication check for drafts**: Modified the blog post route to check user authentication when accessing draft posts, redirecting unauthenticated users to 404
- **Separated validation logic**: Split the post existence and draft status checks into two distinct conditions for clearer control flow
- **Draft indicator UI**: Added a visual warning banner in the blog layout to indicate when a post is in draft status
- **Layout prop update**: Extended `BlogLayout` component to accept and display a `draft` prop

## Implementation Details
- The authentication check uses the `isAuthenticated` utility from the auth module
- Draft posts return a 404 redirect for non-authenticated users, maintaining the appearance that the post doesn't exist
- The draft banner uses Tailwind styling with dark mode support and is only displayed when `draft` is true
- The banner uses semantic amber/warning colors to clearly indicate draft status to authenticated viewers

https://claude.ai/code/session_01DKdPh5Xx54ZppzaRF7psNC