### PR TITLE
Add YouTube embed component and fix broken iframe

### DIFF
--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  videoId: string;
+  title?: string;
+}
+
+export default function YouTube({ videoId, title }: Props) {
+  return (
+    <div className="flex justify-center aspect-video">
+      <iframe
+        className="w-full"
+        height="378px"
+        src={`https://www.youtube.com/embed/${videoId}`}
+        title={title ?? "YouTube video player"}
+        frameBorder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  );
+}

--- a/src/content/blog/obligatory-ai-post.mdx
+++ b/src/content/blog/obligatory-ai-post.mdx
@@ -12,6 +12,8 @@ import Tooltip from '../../components/Tooltip.astro'
 
 import NerdAlert from '../../components/NerdAlert.tsx'
 
+import YouTube from '../../components/YouTube.tsx'
+
 > If you were to ask me to describe AI in two words I’d say “Liar bot”. If I were to ask me to describe AI in two letters I’d say “AI”.&#x20;
 
 > – John Pangalos&#x20;
@@ -26,7 +28,7 @@ But I’m getting ahead of myself, some of <Tooltip client:visible main="you" ho
 
 <Tooltip client:visible main="I’m glad you asked!" hover="Now ask me to eat some ice cream." /> AI or Artificial Intelligence or LLMs or Large Language Models are a essentially a random guessing that tries to guess the next word it thinks should come after the previous word – and all of the words in thousands of <Tooltip client:visible main="pirated books" hover="You don’t have to pay for the rights when you stole the books! It’s a legal loophole!" />, millions of internet articles and a metric ton of unhinged <Tooltip client:visible main="LinkedIn posts" hover="You can even translate to LinkedIn now! It uses AI so you k ow it’s good!" to="https://translate.kagi.com/" />. It can even program. Yes, the nerdy thing that is misunderstood so much by popular culture, can now be done by anyone, include the actors here:
 
-\<iframe width\="1613" height\="1210" src\="https://www.youtube.com/embed/u8qgehH3kEQ" title\="NCIS 2 IDIOTS 1 KEYBOARD" frameborder\="0" allow\="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy\="strict-origin-when-cross-origin" allowfullscreen>\</iframe>
+<YouTube videoId="u8qgehH3kEQ" title="NCIS 2 IDIOTS 1 KEYBOARD" />
 
 And now that I can ”write” code from my phone without touching a compute, I used AI to rewrite my blog in the frontend framework du jour Astro!
 

--- a/src/pages/admin/new/_components/MdxEditorField.tsx
+++ b/src/pages/admin/new/_components/MdxEditorField.tsx
@@ -49,6 +49,12 @@ function InsertComponentButton() {
           insertJsx({ kind: "flow", name: "NerdAlert", props: {} });
         } else if (value === "SpoilerAlert") {
           insertJsx({ kind: "flow", name: "SpoilerAlert", props: {} });
+        } else if (value === "YouTube") {
+          insertJsx({
+            kind: "flow",
+            name: "YouTube",
+            props: { videoId: "" },
+          });
         }
         e.target.value = "";
       }}
@@ -59,6 +65,7 @@ function InsertComponentButton() {
       <option value="Tooltip">Tooltip</option>
       <option value="NerdAlert">Nerd Alert</option>
       <option value="SpoilerAlert">Spoiler Alert</option>
+      <option value="YouTube">YouTube</option>
     </select>
   );
 }

--- a/src/pages/admin/new/_components/jsxComponentDescriptors.tsx
+++ b/src/pages/admin/new/_components/jsxComponentDescriptors.tsx
@@ -179,6 +179,124 @@ function TooltipEditor({ mdastNode }: JsxEditorProps) {
   );
 }
 
+function YouTubeEditor({ mdastNode }: JsxEditorProps) {
+  const updateMdastNode = useMdastNodeUpdater();
+
+  const videoId = getAttrValue(mdastNode.attributes, "videoId");
+  const title = getAttrValue(mdastNode.attributes, "title");
+
+  const [editVideoId, setEditVideoId] = useState(videoId);
+  const [editTitle, setEditTitle] = useState(title);
+
+  function save(close: () => void) {
+    const attrs: typeof mdastNode.attributes = [
+      { type: "mdxJsxAttribute", name: "videoId", value: editVideoId },
+    ];
+    if (editTitle) {
+      attrs.push({ type: "mdxJsxAttribute", name: "title", value: editTitle });
+    }
+    updateMdastNode({ attributes: attrs });
+    close();
+  }
+
+  function resetFields() {
+    setEditVideoId(videoId);
+    setEditTitle(title);
+  }
+
+  function renderTrigger() {
+    if (!videoId) {
+      return (
+        <span
+          role="button"
+          className="cursor-pointer border-b-2 border-dotted border-red-700 text-zinc-400"
+        >
+          empty video
+        </span>
+      );
+    }
+    return (
+      <span
+        role="button"
+        className="inline-block cursor-pointer overflow-hidden rounded border-2 border-red-700"
+      >
+        <img
+          src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+          alt={title || "YouTube thumbnail"}
+          className="block w-[240px]"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex w-full justify-center py-2" contentEditable={false}>
+      <DialogTrigger
+        onOpenChange={(isOpen) => {
+          if (isOpen) {
+            resetFields();
+          }
+        }}
+      >
+        <Pressable>{renderTrigger()}</Pressable>
+        <Popover
+          placement="bottom"
+          offset={4}
+          className="z-50 flex flex-col gap-1 rounded border border-red-600 bg-white p-2 text-[13px] shadow-lg"
+        >
+          <Dialog className="flex flex-col gap-1 outline-none">
+            {({ close }) => (
+              <>
+                <TextField
+                  autoFocus
+                  value={editVideoId}
+                  onChange={setEditVideoId}
+                  className="flex items-center gap-1"
+                >
+                  <Label className="min-w-[40px] font-semibold text-red-900">
+                    id
+                  </Label>
+                  <Input
+                    placeholder="e.g. dQw4w9WgXcQ"
+                    className="w-[200px] rounded-sm border border-zinc-300 px-1 py-px text-[13px]"
+                  />
+                </TextField>
+                <TextField
+                  value={editTitle}
+                  onChange={setEditTitle}
+                  className="flex items-center gap-1"
+                >
+                  <Label className="min-w-[40px] font-semibold text-red-900">
+                    title
+                  </Label>
+                  <Input
+                    placeholder="optional title"
+                    className="w-[200px] rounded-sm border border-zinc-300 px-1 py-px text-[13px]"
+                  />
+                </TextField>
+                <span className="mt-1 flex gap-1">
+                  <Button
+                    onPress={() => save(close)}
+                    className="cursor-pointer rounded-sm bg-red-600 px-2 py-0.5 text-xs text-white"
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    onPress={close}
+                    className="cursor-pointer rounded-sm bg-zinc-200 px-2 py-0.5 text-xs"
+                  >
+                    Cancel
+                  </Button>
+                </span>
+              </>
+            )}
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
+    </div>
+  );
+}
+
 export const blogJsxComponentDescriptors: JsxComponentDescriptor[] = [
   {
     name: "Tooltip",
@@ -210,5 +328,17 @@ export const blogJsxComponentDescriptors: JsxComponentDescriptor[] = [
     props: [],
     hasChildren: false,
     Editor: SpoilerAlertEditor,
+  },
+  {
+    name: "YouTube",
+    kind: "flow",
+    source: "../../components/YouTube.tsx",
+    defaultExport: true,
+    props: [
+      { name: "videoId", type: "string", required: true },
+      { name: "title", type: "string" },
+    ],
+    hasChildren: false,
+    Editor: YouTubeEditor,
   },
 ];


### PR DESCRIPTION
The YouTube iframe in the obligatory.ai.post was escaped by the editor
(\<iframe ...\>) so MDX rendered it as literal text. Replace it with a
new <YouTube /> component that wraps the responsive iframe pattern
already used in the-remaking-of post, and register it in the admin
MDXEditor's "+ Component" dropdown with a thumbnail-preview editor so
authors can insert YouTube videos without hand-writing iframes.

https://claude.ai/code/session_01KLUsZh6bNRgfScz3xNohMM