### PR TITLE
Add localStorage autosave for admin article editor

### DIFF
--- a/src/pages/admin/new/_components/MdxEditorField.tsx
+++ b/src/pages/admin/new/_components/MdxEditorField.tsx
@@ -73,12 +73,19 @@ function InsertComponentButton() {
 export default function MdxEditorField({
   name,
   defaultValue = "",
+  onChange,
 }: {
   name: string;
   defaultValue?: string;
+  onChange?: (value: string) => void;
 }) {
   const editorRef = useRef<MDXEditorMethods>(null);
   const [value, setValue] = useState(defaultValue);
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+    if (onChange) onChange(newValue);
+  };
 
   return (
     <div>
@@ -87,7 +94,7 @@ export default function MdxEditorField({
         <MDXEditor
           ref={editorRef}
           markdown={defaultValue}
-          onChange={setValue}
+          onChange={handleChange}
           contentEditableClassName="prose dark:prose-invert max-w-none min-h-[300px] px-4 py-2"
           plugins={[
             headingsPlugin(),

--- a/src/pages/admin/new/_components/PostForm.tsx
+++ b/src/pages/admin/new/_components/PostForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { actions } from "astro:actions";
 import { Button } from "react-aria-components";
 import MdxEditorField from "./MdxEditorField";
@@ -20,6 +20,11 @@ draft: true
 ---
 
 `;
+
+function getStorageKey(slug?: string): string {
+  if (slug) return `admin-article-edit-${slug}`;
+  return "admin-article-new";
+}
 
 function getLoadingMessage(draft: boolean, isEditing: boolean) {
   if (isEditing) return "Updating...";
@@ -43,17 +48,80 @@ function getStatusColorClass(type: string) {
   return "text-stone-500";
 }
 
+function formatSavedTime(isoString: string): string {
+  try {
+    return new Date(isoString).toLocaleTimeString();
+  } catch {
+    return "";
+  }
+}
+
 export default function PostForm({
   initialData,
 }: {
   initialData?: PostFormData;
 }) {
   const isEditing = !!initialData;
+  const storageKey = getStorageKey(initialData?.slug);
 
   const [status, setStatus] = useState<{
     message: string;
     type: "idle" | "loading" | "success" | "error";
   }>({ message: "", type: "idle" });
+
+  const [localSavedAt, setLocalSavedAt] = useState<string | null>(null);
+  const [localContent, setLocalContent] = useState<string | null>(null);
+  const [contentReady, setContentReady] = useState(false);
+  const [editorKey, setEditorKey] = useState(0);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored) {
+        const parsed = JSON.parse(stored) as { content: string; savedAt: string };
+        setLocalContent(parsed.content);
+        setLocalSavedAt(parsed.savedAt);
+      }
+    } catch {
+      // ignore parse errors
+    }
+    setContentReady(true);
+  }, [storageKey]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, []);
+
+  const handleContentChange = (content: string) => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      try {
+        const savedAt = new Date().toISOString();
+        localStorage.setItem(storageKey, JSON.stringify({ content, savedAt }));
+        setLocalSavedAt(savedAt);
+      } catch {
+        // ignore storage errors
+      }
+    }, 1000);
+  };
+
+  const clearLocalDraft = () => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+    try {
+      localStorage.removeItem(storageKey);
+    } catch {
+      // ignore
+    }
+    setLocalSavedAt(null);
+    setLocalContent(null);
+    setEditorKey((k) => k + 1);
+  };
 
   const handleSubmit = async (
     e: React.FormEvent<HTMLFormElement>,
@@ -86,6 +154,13 @@ export default function PostForm({
       return;
     }
 
+    try {
+      localStorage.removeItem(storageKey);
+    } catch {
+      // ignore
+    }
+    setLocalSavedAt(null);
+
     setStatus({
       message: getSuccessMessage(draft, isEditing),
       type: "success",
@@ -95,58 +170,79 @@ export default function PostForm({
     }, 2000);
   };
 
-  let defaultContent = DEFAULT_CONTENT;
-  if (isEditing) defaultContent = initialData.content;
+  const serverContent = isEditing ? initialData.content : DEFAULT_CONTENT;
+  let defaultContent = serverContent;
+  if (localContent !== null) defaultContent = localContent;
+
   let submitLabel = "Publish";
   if (isEditing) submitLabel = "Update";
   const submitDraft = isEditing && isDraftContent(initialData.content);
 
+  if (!contentReady) return null;
+
   return (
-      <form
-        onSubmit={(e) => handleSubmit(e, submitDraft)}
-        className="mt-8 space-y-4"
-      >
-        <div>
-          <label className="block text-sm font-bold">Content (MDX)</label>
-          <div className="mt-1">
-            <MdxEditorField
-              name="content"
-              defaultValue={defaultContent}
-            />
-          </div>
-        </div>
-
-        {status.type !== "idle" && (
-          <div className={`text-sm ${getStatusColorClass(status.type)}`}>
-            {status.message}
-          </div>
-        )}
-
-        <div className="flex gap-3">
-          <Button
-            type="submit"
-            className="rounded bg-fuchsia-700 px-4 py-2 font-bold text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
+    <form
+      onSubmit={(e) => handleSubmit(e, submitDraft)}
+      className="mt-8 space-y-4"
+    >
+      {localSavedAt && (
+        <div className="flex items-center gap-3 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm dark:border-amber-700 dark:bg-amber-950">
+          <span className="text-amber-800 dark:text-amber-200">
+            Local draft saved at {formatSavedTime(localSavedAt)}
+          </span>
+          <button
+            type="button"
+            onClick={clearLocalDraft}
+            className="text-amber-600 underline hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200"
           >
-            {submitLabel}
-          </Button>
-          {!isEditing && (
-            <Button
-              type="button"
-              onPress={(e) => {
-                const form = (e.target as HTMLElement).closest("form");
-                if (form && form.reportValidity()) {
-                  handleSubmit(
-                    { preventDefault: () => {}, currentTarget: form } as React.FormEvent<HTMLFormElement>,
-                    true,
-                  );
-                }
-              }}
-              className="rounded border border-stone-300 bg-white px-4 py-2 font-bold text-stone-700 hover:bg-stone-100 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-            >
-              Save as Draft
-            </Button>
-          )}
+            Discard
+          </button>
         </div>
-      </form>
+      )}
+
+      <div>
+        <label className="block text-sm font-bold">Content (MDX)</label>
+        <div className="mt-1">
+          <MdxEditorField
+            key={editorKey}
+            name="content"
+            defaultValue={defaultContent}
+            onChange={handleContentChange}
+          />
+        </div>
+      </div>
+
+      {status.type !== "idle" && (
+        <div className={`text-sm ${getStatusColorClass(status.type)}`}>
+          {status.message}
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <Button
+          type="submit"
+          className="rounded bg-fuchsia-700 px-4 py-2 font-bold text-white hover:bg-fuchsia-800 dark:bg-fuchsia-600 dark:hover:bg-fuchsia-700"
+        >
+          {submitLabel}
+        </Button>
+        {!isEditing && (
+          <Button
+            type="button"
+            onPress={(e) => {
+              const form = (e.target as HTMLElement).closest("form");
+              if (form && form.reportValidity()) {
+                handleSubmit(
+                  { preventDefault: () => {}, currentTarget: form } as React.FormEvent<HTMLFormElement>,
+                  true,
+                );
+              }
+            }}
+            className="rounded border border-stone-300 bg-white px-4 py-2 font-bold text-stone-700 hover:bg-stone-100 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+          >
+            Save as Draft
+          </Button>
+        )}
+      </div>
+    </form>
   );
 }


### PR DESCRIPTION
Content is debounced and saved to localStorage every second while editing.
On next visit the draft is restored automatically, with a banner showing
the save time and a Discard button to revert to the server version.
The local draft is cleared after a successful GitHub commit.

Storage keys: admin-article-new (create) / admin-article-edit-{slug} (edit).

https://claude.ai/code/session_015Jwbwsa5NkmCr1myLFVdRT