### PR TITLE
Add lint to CI and unblock the lint script

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,4 +17,12 @@ module.exports = {
     es2017: true,
     node: true,
   },
+  overrides: [
+    {
+      files: ["*.d.ts"],
+      rules: {
+        "@typescript-eslint/triple-slash-reference": "off",
+      },
+    },
+  ],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm lint
+
       - run: pnpm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,3 @@
-{}
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "check": "astro check",
     "cf-typegen": "wrangler types",
     "test": "vitest run",
-    "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
-    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
+    "lint": "prettier --ignore-path .gitignore --ignore-path .prettierignore --check . && eslint --ignore-path .gitignore .",
+    "format": "prettier --ignore-path .gitignore --ignore-path .prettierignore --write ."
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
@@ -25,7 +25,7 @@
     "eslint-config-prettier": "8.10.2",
     "jsdom": "29.1.1",
     "postcss": "8.5.14",
-    "prettier": "2.8.8",
+    "prettier": "3.8.3",
     "prettier-plugin-tailwindcss": "0.8.0",
     "rehype-autolink-headings": "6.1.1",
     "rehype-external-links": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: 0.9.9
-        version: 0.9.9(prettier@2.8.8)(typescript@5.9.3)
+        version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@3.4.19(yaml@2.8.2))
@@ -85,11 +85,11 @@ importers:
         specifier: 8.5.14
         version: 8.5.14
       prettier:
-        specifier: 2.8.8
-        version: 2.8.8
+        specifier: 3.8.3
+        version: 3.8.3
       prettier-plugin-tailwindcss:
         specifier: 0.8.0
-        version: 0.8.0(prettier@2.8.8)
+        version: 0.8.0(prettier@3.8.3)
       rehype-autolink-headings:
         specifier: 6.1.1
         version: 6.1.1
@@ -3707,13 +3707,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -4764,9 +4759,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astrojs/check@0.9.9(prettier@2.8.8)(typescript@5.9.3)':
+  '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.8(prettier@2.8.8)(typescript@5.9.3)
+      '@astrojs/language-server': 2.16.8(prettier@3.8.3)(typescript@5.9.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.3
@@ -4809,7 +4804,7 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
-  '@astrojs/language-server@2.16.8(prettier@2.8.8)(typescript@5.9.3)':
+  '@astrojs/language-server@2.16.8(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.3
@@ -4823,14 +4818,14 @@ snapshots:
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
       volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
       volar-service-html: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@2.8.8)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3)
       volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
       volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
       volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
-      prettier: 2.8.8
+      prettier: 3.8.3
     transitivePeerDependencies:
       - typescript
 
@@ -9141,13 +9136,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.8.0(prettier@2.8.8):
+  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.3):
     dependencies:
-      prettier: 2.8.8
+      prettier: 3.8.3
 
-  prettier@2.8.8: {}
-
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -10038,12 +10031,12 @@ snapshots:
     optionalDependencies:
       '@volar/language-service': 2.4.28
 
-  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@2.8.8):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.28
-      prettier: 2.8.8
+      prettier: 3.8.3
 
   volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -10200,7 +10193,7 @@ snapshots:
       '@vscode/l10n': 0.0.18
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
-      prettier: 3.8.1
+      prettier: 3.8.3
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 9.0.1

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,7 +15,15 @@ import {
   getOrigin,
 } from "../lib/auth";
 import type { UserRecord } from "../lib/auth";
-import { createPost, updatePost, postExists, deletePost, publishPost, slugify, extractTitle } from "../lib/blog";
+import {
+  createPost,
+  updatePost,
+  postExists,
+  deletePost,
+  publishPost,
+  slugify,
+  extractTitle,
+} from "../lib/blog";
 import { env } from "cloudflare:workers";
 
 export const server = {
@@ -172,7 +180,7 @@ export const server = {
         }
 
         const matchingCred = user.credentials.find(
-          (c) => c.credentialId === credential.id
+          (c) => c.credentialId === credential.id,
         );
         if (!matchingCred) {
           throw new ActionError({
@@ -233,10 +241,12 @@ export const server = {
         if (env.ENVIRONMENT === "production") {
           const kv = env.BLOG_PANGALOS_AUTH_KV;
           const existingUser = await getUser(kv);
-          excludeCredentials = (existingUser?.credentials ?? []).map((cred) => ({
-            id: cred.credentialId,
-            transports: cred.transports as string[] | undefined,
-          }));
+          excludeCredentials = (existingUser?.credentials ?? []).map(
+            (cred) => ({
+              id: cred.credentialId,
+              transports: cred.transports as string[] | undefined,
+            }),
+          );
         }
 
         const options = await generateRegistrationOptions({

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ export default function Button({ to, children }: Props) {
   return (
     <Link
       href={to}
-      className="flex justify-end rounded py-1 px-3 text-lg font-bold text-fuchsia-700 underline hover:bg-gray-100 dark:border-fuchsia-400 dark:text-fuchsia-400 dark:hover:bg-stone-800"
+      className="flex justify-end rounded px-3 py-1 text-lg font-bold text-fuchsia-700 underline hover:bg-gray-100 dark:border-fuchsia-400 dark:text-fuchsia-400 dark:hover:bg-stone-800"
     >
       {children}
     </Link>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -7,12 +7,7 @@ interface Props {
   children: ReactNode;
 }
 
-export default function Link({
-  to,
-  className = "",
-  style,
-  children,
-}: Props) {
+export default function Link({ to, className = "", style, children }: Props) {
   return (
     <a
       className={`-mx-0.5 p-0.5 text-orange-600 transition-all duration-200 hover:bg-orange-600 hover:text-white dark:text-orange-400 dark:hover:bg-orange-400 dark:hover:text-slate-700${className ? ` ${className}` : ""}`}

--- a/src/components/TooltipReact.test.tsx
+++ b/src/components/TooltipReact.test.tsx
@@ -128,9 +128,7 @@ describe("Tooltip component", () => {
       const { container } = render(
         <Tooltip main="tap me" hover="info" to="https://example.com" />,
       );
-      const span = container.querySelector(
-        ".text-orange-600",
-      );
+      const span = container.querySelector(".text-orange-600");
       expect(span).not.toBeNull();
       expect(span!.textContent).toBe("tap me");
     });

--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -5,7 +5,7 @@ interface Props {
 
 export default function YouTube({ videoId, title }: Props) {
   return (
-    <div className="flex justify-center aspect-video">
+    <div className="flex aspect-video justify-center">
       <iframe
         className="w-full"
         height="378px"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -32,7 +32,7 @@ export async function getUser(kv: KVNamespace): Promise<UserRecord | null> {
 
 export async function saveUser(
   kv: KVNamespace,
-  user: UserRecord
+  user: UserRecord,
 ): Promise<void> {
   await kv.put(`user:${ALLOWED_EMAIL}`, JSON.stringify(user));
 }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -186,7 +186,11 @@ export async function listPosts(): Promise<
             repo: GITHUB_REPO_NAME,
             path: f.path,
           });
-          if (!Array.isArray(fileData) && "content" in fileData && fileData.content) {
+          if (
+            !Array.isArray(fileData) &&
+            "content" in fileData &&
+            fileData.content
+          ) {
             const content = atob(fileData.content.replace(/\n/g, ""));
             const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
             if (match) {
@@ -207,14 +211,17 @@ export async function listPosts(): Promise<
 
     return posts;
   } catch (e: unknown) {
-    if (e instanceof Error && "status" in e && (e as { status: number }).status === 404) return [];
+    if (
+      e instanceof Error &&
+      "status" in e &&
+      (e as { status: number }).status === 404
+    )
+      return [];
     throw e;
   }
 }
 
-export async function deletePost(
-  slug: string,
-): Promise<void> {
+export async function deletePost(slug: string): Promise<void> {
   const octokit = getOctokit();
   const filePath = `${CONTENT_PATH}/${slug}.mdx`;
 
@@ -273,9 +280,7 @@ export async function publishPost(slug: string): Promise<void> {
   });
 }
 
-export async function getPost(
-  slug: string,
-): Promise<RawPost | null> {
+export async function getPost(slug: string): Promise<RawPost | null> {
   const octokit = getOctokit();
   const filePath = `${CONTENT_PATH}/${slug}.mdx`;
 
@@ -328,9 +333,7 @@ export async function updatePost(
   });
 }
 
-export async function postExists(
-  slug: string,
-): Promise<boolean> {
+export async function postExists(slug: string): Promise<boolean> {
   const octokit = getOctokit();
   const filePath = `${CONTENT_PATH}/${slug}.mdx`;
 

--- a/src/lib/passkey-login.ts
+++ b/src/lib/passkey-login.ts
@@ -6,7 +6,7 @@ import {
 
 const form = document.getElementById("login-form") as HTMLFormElement;
 const submitBtn = form.querySelector(
-  "button[type=submit]"
+  "button[type=submit]",
 ) as HTMLButtonElement;
 const successDiv = document.getElementById("status-success") as HTMLDivElement;
 const errorDiv = document.getElementById("status-error") as HTMLDivElement;
@@ -68,7 +68,7 @@ form.addEventListener("submit", async (e) => {
         // Fall through to registration so the user can create a new passkey.
         if (authErr.name === "NotAllowedError") {
           showSuccess(
-            "No passkey found for this domain. Registering a new one..."
+            "No passkey found for this domain. Registering a new one...",
           );
         } else {
           throw authErr;

--- a/src/pages/admin/_components/DeletePostButton.tsx
+++ b/src/pages/admin/_components/DeletePostButton.tsx
@@ -7,11 +7,7 @@ interface Props {
 
 export default function DeletePostButton({ slug }: Props) {
   const handleDelete = async () => {
-    if (
-      !confirm(
-        `Delete "${slug}"? This will commit a deletion to the repo.`,
-      )
-    )
+    if (!confirm(`Delete "${slug}"? This will commit a deletion to the repo.`))
       return;
 
     const { error } = await actions.blog.delete({ slug });

--- a/src/pages/admin/_components/PublishPostButton.tsx
+++ b/src/pages/admin/_components/PublishPostButton.tsx
@@ -7,7 +7,11 @@ interface Props {
 
 export default function PublishPostButton({ slug }: Props) {
   const handlePublish = async () => {
-    if (!confirm(`Publish "${slug}"? This will make it live after the site rebuilds.`))
+    if (
+      !confirm(
+        `Publish "${slug}"? This will make it live after the site rebuilds.`,
+      )
+    )
       return;
 
     const { error } = await actions.blog.publish({ slug });

--- a/src/pages/admin/login/_components/LoginForm.tsx
+++ b/src/pages/admin/login/_components/LoginForm.tsx
@@ -4,12 +4,7 @@ import {
   startRegistration,
   startAuthentication,
 } from "@simplewebauthn/browser";
-import {
-  Button,
-  TextField,
-  Input,
-  Label,
-} from "react-aria-components";
+import { Button, TextField, Input, Label } from "react-aria-components";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
@@ -111,16 +106,9 @@ export default function LoginForm() {
   return (
     <>
       <form onSubmit={handleSubmit}>
-        <TextField
-          type="email"
-          isRequired
-          value={email}
-          onChange={setEmail}
-        >
+        <TextField type="email" isRequired value={email} onChange={setEmail}>
           <Label className="mb-2 block text-sm font-medium">Email</Label>
-          <Input
-            className="mb-4 w-full rounded border border-stone-300 bg-white px-3 py-2 text-stone-900 focus:border-fuchsia-500 focus:outline-none focus:ring-1 focus:ring-fuchsia-500 dark:border-stone-600 dark:bg-stone-800 dark:text-white"
-          />
+          <Input className="mb-4 w-full rounded border border-stone-300 bg-white px-3 py-2 text-stone-900 focus:border-fuchsia-500 focus:outline-none focus:ring-1 focus:ring-fuchsia-500 dark:border-stone-600 dark:bg-stone-800 dark:text-white" />
         </TextField>
         <Button
           type="submit"

--- a/src/pages/admin/new/_components/PostForm.test.tsx
+++ b/src/pages/admin/new/_components/PostForm.test.tsx
@@ -14,8 +14,18 @@ vi.mock("astro:actions", () => ({
 
 // Mock MDXEditor since it requires browser APIs not available in jsdom
 vi.mock("./MdxEditorField", () => ({
-  default: ({ name, defaultValue }: { name: string; defaultValue?: string }) => (
-    <textarea data-testid="mdx-editor" name={name} defaultValue={defaultValue} />
+  default: ({
+    name,
+    defaultValue,
+  }: {
+    name: string;
+    defaultValue?: string;
+  }) => (
+    <textarea
+      data-testid="mdx-editor"
+      name={name}
+      defaultValue={defaultValue}
+    />
   ),
 }));
 
@@ -24,7 +34,8 @@ afterEach(cleanup);
 const sampleData: PostFormData = {
   slug: "test-post",
   sha: "abc123",
-  content: '---\nauthor: "John Pangalos"\ntitle: "Test Post Title"\n---\n\n## Hello\n\nSome content here.',
+  content:
+    '---\nauthor: "John Pangalos"\ntitle: "Test Post Title"\n---\n\n## Hello\n\nSome content here.',
 };
 
 describe("PostForm", () => {

--- a/src/pages/admin/new/_components/PostForm.tsx
+++ b/src/pages/admin/new/_components/PostForm.tsx
@@ -33,7 +33,8 @@ function getLoadingMessage(draft: boolean, isEditing: boolean) {
 }
 
 function getSuccessMessage(draft: boolean, isEditing: boolean) {
-  if (isEditing) return "Post updated! It will be live after the site rebuilds.";
+  if (isEditing)
+    return "Post updated! It will be live after the site rebuilds.";
   if (draft) return "Draft saved to repo!";
   return "Post committed to repo! It will be live after the site rebuilds.";
 }
@@ -79,7 +80,10 @@ export default function PostForm({
     try {
       const stored = localStorage.getItem(storageKey);
       if (stored) {
-        const parsed = JSON.parse(stored) as { content: string; savedAt: string };
+        const parsed = JSON.parse(stored) as {
+          content: string;
+          savedAt: string;
+        };
         setLocalContent(parsed.content);
         setLocalSavedAt(parsed.savedAt);
       }
@@ -232,7 +236,10 @@ export default function PostForm({
               const form = (e.target as HTMLElement).closest("form");
               if (form && form.reportValidity()) {
                 handleSubmit(
-                  { preventDefault: () => {}, currentTarget: form } as React.FormEvent<HTMLFormElement>,
+                  {
+                    preventDefault: () => undefined,
+                    currentTarget: form,
+                  } as React.FormEvent<HTMLFormElement>,
                   true,
                 );
               }

--- a/src/pages/admin/new/_components/jsxComponentDescriptors.tsx
+++ b/src/pages/admin/new/_components/jsxComponentDescriptors.tsx
@@ -96,19 +96,19 @@ function TooltipEditor({ mdastNode }: JsxEditorProps) {
 
   return (
     <span className="inline-flex" contentEditable={false}>
-      <DialogTrigger onOpenChange={(isOpen) => {
-        if (isOpen) {
-          resetFields();
-        }
-      }}>
+      <DialogTrigger
+        onOpenChange={(isOpen) => {
+          if (isOpen) {
+            resetFields();
+          }
+        }}
+      >
         <Pressable>
           <span
             role="button"
             className="cursor-pointer border-b-2 border-dotted border-fuchsia-700"
           >
-            {main || (
-              <span className="text-zinc-400">empty tooltip</span>
-            )}
+            {main || <span className="text-zinc-400">empty tooltip</span>}
           </span>
         </Pressable>
         <Popover

--- a/src/styles/hightlight.css
+++ b/src/styles/hightlight.css
@@ -33,8 +33,8 @@ pre[class*="language-"] {
   background: hsl(220, 13%, 18%);
   color: hsl(220, 14%, 71%);
   text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-  font-family: "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono",
-    monospace;
+  font-family:
+    "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
   direction: ltr;
   text-align: left;
   white-space: pre;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,43 +5,41 @@
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
-  "routes": [
-    { "pattern": "blog.pangalos.dev", "custom_domain": true }
-  ],
+  "routes": [{ "pattern": "blog.pangalos.dev", "custom_domain": true }],
   "vars": {
-    "ENVIRONMENT": "production"
+    "ENVIRONMENT": "production",
   },
   "observability": {
-    "enabled": true
+    "enabled": true,
   },
   "kv_namespaces": [
     {
       "binding": "BLOG_PANGALOS_AUTH_KV",
-      "id": "0210a862785a4ed69e941d15237eed1c"
+      "id": "0210a862785a4ed69e941d15237eed1c",
     },
     {
       "binding": "BLOG_PANGALOS_SESSION",
-      "id": "b5c364a241ef458a9333ff51f62862b5"
-    }
+      "id": "b5c364a241ef458a9333ff51f62862b5",
+    },
   ],
   "env": {
     "preview": {
       "vars": {
-        "ENVIRONMENT": "preview"
+        "ENVIRONMENT": "preview",
       },
       "observability": {
-        "enabled": true
+        "enabled": true,
       },
       "kv_namespaces": [
         {
           "binding": "BLOG_PANGALOS_AUTH_KV",
-          "id": "0210a862785a4ed69e941d15237eed1c"
+          "id": "0210a862785a4ed69e941d15237eed1c",
         },
         {
           "binding": "BLOG_PANGALOS_SESSION",
-          "id": "b5c364a241ef458a9333ff51f62862b5"
-        }
-      ]
-    }
-  }
+          "id": "b5c364a241ef458a9333ff51f62862b5",
+        },
+      ],
+    },
+  },
 }


### PR DESCRIPTION
The lint script was silently broken: prettier-plugin-tailwindcss@0.8.0
requires Prettier 3, but the project was on Prettier 2.8.8, so
`--plugin-search-dir=.` made every prettier invocation crash. Lint was
also missing from CI, so the breakage went unnoticed.

- Upgrade prettier to 3.8.3 and register the tailwind plugin via
  .prettierrc (Prettier 3 dropped --plugin-search-dir auto-discovery).
- Honor .prettierignore in the lint/format scripts; previously the
  --ignore-path .gitignore flag silently replaced .prettierignore, so
  .mdx and pnpm-lock.yaml were being formatted against the project's
  stated intent.
- Reformat affected source files with Prettier 3.
- Fix two eslint errors that would have blocked CI: triple-slash
  reference in env.d.ts (disable rule for *.d.ts — idiomatic for
  Astro) and an empty preventDefault stub in PostForm.tsx.
- Wire `pnpm lint` into the CI workflow.