### PR TITLE
Color prose links orange to match the site's Link component

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,6 +8,8 @@ module.exports = {
         slate: {
           css: {
             "--tw-prose-headings": theme("colors.amber[600]"),
+            "--tw-prose-links": theme("colors.orange[600]"),
+            "--tw-prose-invert-links": theme("colors.orange[400]"),
           },
         },
       }),


### PR DESCRIPTION
Plain markdown links in post content rendered with the typography plugin's default dark slate link color, which reads as black. Orange styling only existed on the custom `Link`/`Tooltip` components and heading anchors.

This sets `--tw-prose-links` to orange-600 and `--tw-prose-invert-links` to orange-400 in the existing slate typography customization, matching the colors `Link.tsx` uses. Heading anchors keep their amber color via the more specific `global.css` rule.

Verified in a production build that the generated CSS cascade resolves prose links to `#ea580c` (light) and `#fb923c` (dark).

https://claude.ai/code/session_01VUbknPFh4qYTML8ETTVMgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUbknPFh4qYTML8ETTVMgm)_